### PR TITLE
chore: move tslib to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "loggatron",
       "version": "1.2.0-beta.1",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      },
       "devDependencies": {
         "@commitlint/cli": "^20.1.0",
         "@commitlint/config-conventional": "^20.0.0",
@@ -29,6 +26,7 @@
         "prettier": "^3.2.4",
         "rollup": "^4.9.6",
         "standard-version": "^9.5.0",
+        "tslib": "^2.8.1",
         "typescript": "^5.3.3",
         "vitest": "^1.2.0"
       }
@@ -7099,6 +7097,7 @@
       "version": "2.8.1",
       "resolved": "https://artifactory.hootops.com/artifactory/api/npm/hootsuite-npm/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "peer": true
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rollup": "^4.9.6",
     "standard-version": "^9.5.0",
     "typescript": "^5.3.3",
+    "tslib": "^2.8.1",
     "vitest": "^1.2.0"
   },
   "sideEffects": false,
@@ -86,9 +87,6 @@
       "prettier --write",
       "eslint --fix"
     ]
-  },
-  "dependencies": {
-    "tslib": "^2.8.1"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Move tslib from dependencies to devDependencies since it's only used during build time by @rollup/plugin-typescript and is not required at runtime. This reduces the package size for end users and maintains zero runtime dependencies.